### PR TITLE
docs: add repository map reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/437763c6ed04421a9b3fbc439f24b523)](https://www.codacy.com/gh/societe-generale/failover/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=societe-generale/failover&amp;utm_campaign=Badge_Grade)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.societegenerale.failover/failover/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.societegenerale.failover/failover)
 [![Maven Central](https://img.shields.io/maven-central/v/com.societegenerale.failover/failover.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.societegenerale.failover/failover)
+[![Project Map](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/societegeneralefailover/)
 > ***Failover library - To manage the failover on referential systems***
 
 **"This library is to help to enable a failover to handle the failures on external services by keeping a local store for such api responses"**


### PR DESCRIPTION
## Summary
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/societegeneralefailover/).

## Details
Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project. In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.

## Checklist:
- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR
- [x] I have verified all the modules and confirmed no impacts

## Related issue : 
Documentation-only change