### PR TITLE
refactor: all failover store to return a copy of ReferentialPayload

### DIFF
--- a/docs/documentation/ADR.md
+++ b/docs/documentation/ADR.md
@@ -264,3 +264,93 @@ Provide an option to customize the key generator for a specific failover
 #### Consequences
 * If the custom key generator (name) is missing, an exception may occur.
 ___
+
+## 10. DefaultFailoverStore — Defensive Copy for Immutability
+
+**Date : 25-MAY-2026**
+
+#### Status
+Accepted
+
+#### Context
+`FailoverStore` implementations hold `ReferentialPayload` instances in memory (ConcurrentHashMap, Caffeine cache).
+If the same object reference is shared between the store and the caller, mutations on either side corrupt the stored state silently.
+Additionally, data recovered from the failover store must always be distinguishable from a live response — a recovered payload must never appear as `upToDate=true`.
+
+#### Decision
+Introduce `DefaultFailoverStore<T>` as a mandatory decorator around every concrete `FailoverStore`.
+
+* **Before storing (`store`, `delete`)**: call `referentialPayload.copy().withUpToDate(false)` to write a defensive copy with `upToDate` forced to `false`. The caller retains their original object; the store holds its own independent copy.
+* **Before returning (`find`)**: map the result through `copy().withUpToDate(false)` so the caller receives a fresh copy that cannot be used to mutate internal store state, and `upToDate` is always `false` for recovered data.
+* **`copy()` contract** on `ReferentialPayload`: shallow copy of all fields. Payload reference is shared, but field-level mutations (name, key, upToDate, asOf, expireOn) on either side are isolated.
+* `cleanByExpiry` delegates directly — no payload is produced, so no copy is needed.
+
+```
+store(payload)   →  delegate.store( payload.copy().withUpToDate(false) )
+delete(payload)  →  delegate.delete( payload.copy().withUpToDate(false) )
+find(name, key)  →  delegate.find(name, key).map( r -> r.copy().withUpToDate(false) )
+cleanByExpiry    →  delegate.cleanByExpiry(expiry)   // passthrough
+```
+
+#### Consequences
+* Every store/find operation allocates one extra `ReferentialPayload` object — negligible overhead.
+* `upToDate` is always `false` for data served from the failover store, regardless of what was stored. Callers can rely on this invariant unconditionally.
+* Mutating the payload object received from `find()` has no effect on the store.
+* `DefaultFailoverStore` is automatically applied to all `FailoverStore` beans via `FailoverStoreBeanPostProcessor` (see ADR 11) — no manual wiring required.
+___
+
+## 11. FailoverStoreBeanPostProcessor — Uniform Store Wrapping via BeanPostProcessor
+
+**Date : 25-MAY-2026**
+
+#### Status
+Accepted
+
+#### Context
+Every `FailoverStore` bean — whether auto-configured (INMEMORY, CAFFEINE, JDBC) or user-provided (CUSTOM) — must be consistently wrapped with:
+1. `DefaultFailoverStore` — enforces `upToDate=false` and defensive copy (see ADR 10).
+2. `FailoverStoreAsync` — makes `store`, `delete`, and `cleanByExpiry` asynchronous via Spring `@Async`.
+
+Previously, each auto-configuration class manually constructed the wrapping chain, leading to duplication and risk of inconsistency for custom stores. User-defined `FailoverStore` beans received no wrapping at all.
+
+#### Decision
+Implement `FailoverStoreBeanPostProcessor implements BeanPostProcessor` and register it as a `static @Bean` in `FailoverAutoConfiguration`.
+
+**Wrapping rule** applied in `postProcessBeforeInitialization`:
+```
+if bean is FailoverStore
+   AND NOT already FailoverStoreAsync
+   AND NOT already DefaultFailoverStore
+→ return new FailoverStoreAsync<>(new DefaultFailoverStore<>(bean))
+otherwise
+→ return bean unchanged
+```
+
+The guard prevents double-wrapping when the BPP encounters beans that are already part of the chain.
+
+All auto-configuration `@Bean` methods (INMEMORY, CAFFEINE, JDBC) return the raw concrete store only. The BPP applies the wrapping uniformly for all.
+
+**Why `postProcessBeforeInitialization` and not `postProcessAfterInitialization`:**
+
+Spring's bean lifecycle runs in this order:
+```
+1. Bean instantiated
+2. Dependencies injected
+3. postProcessBeforeInitialization   ← BPP fires here, returns FailoverStoreAsync wrapper
+4. @PostConstruct / afterPropertiesSet
+5. postProcessAfterInitialization    ← Spring AOP (AsyncAnnotationBeanPostProcessor) runs here
+6. Bean ready
+```
+
+By returning `FailoverStoreAsync` in step 3, Spring's `AsyncAnnotationBeanPostProcessor` (step 5) sees the wrapper as the bean and creates an AOP proxy around it, enabling `@Async` on its methods.
+If wrapping happened in step 5 (`postProcessAfterInitialization`), the returned `FailoverStoreAsync` would be registered after AOP infrastructure has already run, and `@Async` would be silently skipped — `store`, `delete`, and `cleanByExpiry` would execute synchronously.
+
+**Why `static @Bean`:**
+`BeanPostProcessor` beans are instantiated very early in the Spring context lifecycle, before regular `@Configuration` class instances are created. Declaring the bean `static` avoids eager instantiation of the `@Configuration` class and prevents proxy-related issues.
+
+#### Consequences
+* All `FailoverStore` beans — auto-configured or user-defined — get the same `FailoverStoreAsync → DefaultFailoverStore → concrete store` chain automatically.
+* Custom store authors define only the raw `FailoverStore` implementation; wrapping is transparent. **CustomStore should not use any bean post construct or bean init**
+* `FailoverStoreAsync` and `DefaultFailoverStore` themselves are excluded from re-wrapping by the guard.
+* BPP ordering relative to `AsyncAnnotationBeanPostProcessor` is safe because `postProcessBeforeInitialization` always precedes AOP proxy creation.
+___

--- a/failover-core/src/main/java/com/societegenerale/failover/core/payload/ReferentialPayload.java
+++ b/failover-core/src/main/java/com/societegenerale/failover/core/payload/ReferentialPayload.java
@@ -22,23 +22,65 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/// @author Anand Manissery
+/**
+ * Envelope that wraps a referential payload with metadata used by the failover mechanism.
+ *
+ * <p>Each instance represents a single cached entry identified by a ({@code name}, {@code key}) pair.
+ * The {@code upToDate} flag signals whether the payload reflects a live response ({@code true})
+ * or was served from the failover store ({@code false}). {@code asOf} records when the payload
+ * was last written; {@code expireOn} drives eviction via {@link com.societegenerale.failover.core.store.FailoverStore#cleanByExpiry}.
+ *
+ * @param <T> the type of the business payload
+ * @author Anand Manissery
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class ReferentialPayload<T> {
 
+    /** Logical name of the referential (e.g. entity type or domain identifier). */
     private String name;
 
+    /** Unique key within the referential (e.g. entity ID or request key). */
     private String key;
 
+    /**
+     * {@code true} if the payload was obtained from the live source; {@code false} if it was
+     * served from the failover store.
+     */
     private boolean upToDate;
 
+    /** Timestamp at which this payload was last retried from the golden source. */
     private LocalDateTime asOf;
 
+    /** Timestamp after which this payload is eligible for eviction. */
     private LocalDateTime expireOn;
 
+    /** The actual business payload. */
     private T payload;
+
+    /**
+     * Sets the {@code upToDate} flag and returns {@code this} for chaining.
+     *
+     * @param upToDate {@code true} for a live payload, {@code false} for a failover payload
+     * @return this instance
+     */
+    public ReferentialPayload<T> withUpToDate(boolean upToDate) {
+        this.upToDate = upToDate;
+        return this;
+    }
+
+    /**
+     * Creates a shallow copy of this payload, preserving all field values.
+     *
+     * <p>Intended to be combined with {@link #withUpToDate} to produce a modified copy
+     * without mutating the original, e.g. {@code payload.copy().withUpToDate(false)}.
+     *
+     * @return a new {@link ReferentialPayload} with the same field values
+     */
+    public ReferentialPayload<T> copy() {
+        return new ReferentialPayload<>(this.name, this.key, this.upToDate, this.asOf, this.expireOn, this.payload);
+    }
 
     @Override
     public String toString() {

--- a/failover-core/src/main/java/com/societegenerale/failover/core/store/DefaultFailoverStore.java
+++ b/failover-core/src/main/java/com/societegenerale/failover/core/store/DefaultFailoverStore.java
@@ -1,0 +1,76 @@
+package com.societegenerale.failover.core.store;
+
+import com.societegenerale.failover.core.payload.ReferentialPayload;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static java.lang.Boolean.FALSE;
+
+/**
+ * Default {@link FailoverStore} decorator that ensures every payload written to or read from
+ * the delegate store has its {@code upToDate} flag forced to {@code false}.
+ *
+ * <p>This prevents stale failover data from being mistaken for a fresh response: consumers
+ * can check {@code upToDate} to distinguish a live result from a failover fallback.
+ * The {@link #cleanByExpiry} operation is delegated as-is since it does not produce payloads.
+ *
+ * @param <T> the type of the payload held by each referential entry
+ */
+@RequiredArgsConstructor
+public class DefaultFailoverStore<T> implements FailoverStore<T> {
+
+    @Getter
+    private final FailoverStore<T> failoverStore;
+
+    /**
+     * Stores a copy of the given payload with {@code upToDate} forced to {@code false},
+     * then delegates to the underlying store.
+     *
+     * @param referentialPayload the payload to persist; must not be {@code null}
+     * @throws FailoverStoreException if the delegate store operation fails
+     */
+    @Override
+    public void store(ReferentialPayload<T> referentialPayload) throws FailoverStoreException {
+        failoverStore.store(referentialPayload.copy().withUpToDate(FALSE));
+    }
+
+    /**
+     * Deletes a copy of the given payload with {@code upToDate} forced to {@code false},
+     * then delegates to the underlying store.
+     *
+     * @param referentialPayload the payload to remove; must not be {@code null}
+     * @throws FailoverStoreException if the delegate delete operation fails
+     */
+    @Override
+    public void delete(ReferentialPayload<T> referentialPayload) throws FailoverStoreException {
+        failoverStore.delete(referentialPayload.copy().withUpToDate(FALSE));
+    }
+
+    /**
+     * Looks up a payload by name and key, returning a copy with {@code upToDate} forced to
+     * {@code false} if found.
+     *
+     * @param name the referential name
+     * @param key  the unique key within that referential
+     * @return an {@link Optional} containing the payload with {@code upToDate=false}, or empty if not found
+     * @throws FailoverStoreException if the delegate lookup operation fails
+     */
+    @Override
+    public Optional<ReferentialPayload<T>> find(String name, String key) throws FailoverStoreException {
+        return failoverStore.find(name, key).map(r -> r.copy().withUpToDate(false));
+    }
+
+    /**
+     * Delegates expiry-based cleanup directly to the underlying store without modification.
+     *
+     * @param expiry the cutoff datetime; entries expiring at or before this value are removed
+     * @throws FailoverStoreException if the delegate cleanup operation fails
+     */
+    @Override
+    public void cleanByExpiry(LocalDateTime expiry) throws FailoverStoreException {
+        failoverStore.cleanByExpiry(expiry);
+    }
+}

--- a/failover-core/src/main/java/com/societegenerale/failover/core/store/FailoverStore.java
+++ b/failover-core/src/main/java/com/societegenerale/failover/core/store/FailoverStore.java
@@ -22,14 +22,48 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
+ * Persistence contract for failover referential data.
+ *
+ * <p>Implementations are responsible for storing, retrieving, and evicting
+ * {@link ReferentialPayload} entries so that the failover mechanism can serve
+ * cached data when the primary source is unavailable.
+ *
+ * @param <T> the type of the payload held by each referential entry
  * @author Anand Manissery
  */
 public interface FailoverStore<T> {
+
+    /**
+     * Persists or updates a referential payload entry.
+     *
+     * @param referentialPayload the payload to store; must not be {@code null}
+     * @throws FailoverStoreException if the underlying store operation fails
+     */
     void store(ReferentialPayload<T> referentialPayload) throws FailoverStoreException;
 
+    /**
+     * Removes a referential payload entry from the store.
+     *
+     * @param referentialPayload the payload to remove; must not be {@code null}
+     * @throws FailoverStoreException if the underlying delete operation fails
+     */
     void delete(ReferentialPayload<T> referentialPayload) throws FailoverStoreException;
 
+    /**
+     * Looks up a referential payload by its logical name and key.
+     *
+     * @param name the referential name (e.g. the entity or endpoint identifier)
+     * @param key  the unique key within that referential
+     * @return an {@link Optional} containing the stored payload, or empty if not found
+     * @throws FailoverStoreException if the underlying lookup operation fails
+     */
     Optional<ReferentialPayload<T>> find(String name, String key) throws FailoverStoreException;
 
-    void cleanByExpiry(LocalDateTime expiry)  throws FailoverStoreException;
+    /**
+     * Evicts all entries whose expiry timestamp is on or before the given datetime.
+     *
+     * @param expiry the cutoff datetime; entries expiring at or before this value are removed
+     * @throws FailoverStoreException if the underlying cleanup operation fails
+     */
+    void cleanByExpiry(LocalDateTime expiry) throws FailoverStoreException;
 }

--- a/failover-core/src/test/java/com/societegenerale/failover/core/store/DefaultFailoverStoreTest.java
+++ b/failover-core/src/test/java/com/societegenerale/failover/core/store/DefaultFailoverStoreTest.java
@@ -36,7 +36,7 @@ class DefaultFailoverStoreTest {
     // --- store() ---
 
     @Test
-    void store_delegatesWithUpToDateFalse() throws FailoverStoreException {
+    void storeDelegatesWithUpToDateFalse() throws FailoverStoreException {
         ReferentialPayload<String> original = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ReferentialPayload<String>> captor = ArgumentCaptor.forClass(ReferentialPayload.class);
@@ -54,7 +54,7 @@ class DefaultFailoverStoreTest {
     }
 
     @Test
-    void store_propagatesFailoverStoreException() throws FailoverStoreException {
+    void storePropagatesFailoverStoreException() throws FailoverStoreException {
         ReferentialPayload<String> original = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
         doThrow(new FailoverStoreException("error", new RuntimeException())).when(delegate).store(any());
 
@@ -64,7 +64,7 @@ class DefaultFailoverStoreTest {
     // --- delete() ---
 
     @Test
-    void delete_delegatesWithUpToDateFalse() throws FailoverStoreException {
+    void deleteDelegatesWithUpToDateFalse() throws FailoverStoreException {
         ReferentialPayload<String> original = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ReferentialPayload<String>> captor = ArgumentCaptor.forClass(ReferentialPayload.class);
@@ -82,7 +82,7 @@ class DefaultFailoverStoreTest {
     }
 
     @Test
-    void delete_propagatesFailoverStoreException() throws FailoverStoreException {
+    void deletePropagatesFailoverStoreException() throws FailoverStoreException {
         ReferentialPayload<String> original = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
         doThrow(new FailoverStoreException("error", new RuntimeException())).when(delegate).delete(any());
 
@@ -92,7 +92,7 @@ class DefaultFailoverStoreTest {
     // --- find() ---
 
     @Test
-    void find_presentResult_returnsWithUpToDateFalse() throws FailoverStoreException {
+    void findPresentResultReturnsWithUpToDateFalse() throws FailoverStoreException {
         ReferentialPayload<String> found = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
         when(delegate.find("name", "key")).thenReturn(Optional.of(found));
 
@@ -108,7 +108,7 @@ class DefaultFailoverStoreTest {
     }
 
     @Test
-    void find_emptyResult_returnsEmpty() throws FailoverStoreException {
+    void findEmptyResultReturnsEmpty() throws FailoverStoreException {
         when(delegate.find("name", "key")).thenReturn(Optional.empty());
 
         Optional<ReferentialPayload<String>> result = store.find("name", "key");
@@ -117,7 +117,7 @@ class DefaultFailoverStoreTest {
     }
 
     @Test
-    void find_propagatesFailoverStoreException() throws FailoverStoreException {
+    void findPropagatesFailoverStoreException() throws FailoverStoreException {
         when(delegate.find("name", "key")).thenThrow(new FailoverStoreException("error", new RuntimeException()));
 
         assertThatThrownBy(() -> store.find("name", "key")).isInstanceOf(FailoverStoreException.class);
@@ -126,7 +126,7 @@ class DefaultFailoverStoreTest {
     // --- cleanByExpiry() ---
 
     @Test
-    void cleanByExpiry_delegatesDirectly() throws FailoverStoreException {
+    void cleanByExpiryDelegatesDirectly() throws FailoverStoreException {
         LocalDateTime expiry = LocalDateTime.now();
 
         store.cleanByExpiry(expiry);
@@ -135,7 +135,7 @@ class DefaultFailoverStoreTest {
     }
 
     @Test
-    void cleanByExpiry_propagatesFailoverStoreException() throws FailoverStoreException {
+    void cleanByExpiryPropagatesFailoverStoreException() throws FailoverStoreException {
         LocalDateTime expiry = LocalDateTime.now();
         doThrow(new FailoverStoreException("error", new RuntimeException())).when(delegate).cleanByExpiry(any());
 

--- a/failover-core/src/test/java/com/societegenerale/failover/core/store/DefaultFailoverStoreTest.java
+++ b/failover-core/src/test/java/com/societegenerale/failover/core/store/DefaultFailoverStoreTest.java
@@ -1,0 +1,144 @@
+package com.societegenerale.failover.core.store;
+
+import com.societegenerale.failover.core.payload.ReferentialPayload;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultFailoverStoreTest {
+
+    private static final LocalDateTime AS_OF = LocalDateTime.of(2024, 1, 1, 10, 0);
+
+    private static final LocalDateTime EXPIRE_ON = LocalDateTime.of(2024, 1, 2, 10, 0);
+
+    @Mock
+    private FailoverStore<String> delegate;
+
+    private DefaultFailoverStore<String> store;
+
+    @BeforeEach
+    void setUp() {
+        store = new DefaultFailoverStore<>(delegate);
+    }
+
+    // --- store() ---
+
+    @Test
+    void store_delegatesWithUpToDateFalse() throws FailoverStoreException {
+        ReferentialPayload<String> original = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ReferentialPayload<String>> captor = ArgumentCaptor.forClass(ReferentialPayload.class);
+
+        store.store(original);
+
+        verify(delegate).store(captor.capture());
+        ReferentialPayload<String> captured = captor.getValue();
+        assertThat(captured.isUpToDate()).isFalse();
+        assertThat(captured.getName()).isEqualTo("name");
+        assertThat(captured.getKey()).isEqualTo("key");
+        assertThat(captured.getAsOf()).isEqualTo(AS_OF);
+        assertThat(captured.getExpireOn()).isEqualTo(EXPIRE_ON);
+        assertThat(captured.getPayload()).isEqualTo("payload");
+    }
+
+    @Test
+    void store_propagatesFailoverStoreException() throws FailoverStoreException {
+        ReferentialPayload<String> original = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
+        doThrow(new FailoverStoreException("error", new RuntimeException())).when(delegate).store(any());
+
+        assertThatThrownBy(() -> store.store(original)).isInstanceOf(FailoverStoreException.class);
+    }
+
+    // --- delete() ---
+
+    @Test
+    void delete_delegatesWithUpToDateFalse() throws FailoverStoreException {
+        ReferentialPayload<String> original = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ReferentialPayload<String>> captor = ArgumentCaptor.forClass(ReferentialPayload.class);
+
+        store.delete(original);
+
+        verify(delegate).delete(captor.capture());
+        ReferentialPayload<String> captured = captor.getValue();
+        assertThat(captured.isUpToDate()).isFalse();
+        assertThat(captured.getName()).isEqualTo("name");
+        assertThat(captured.getKey()).isEqualTo("key");
+        assertThat(captured.getAsOf()).isEqualTo(AS_OF);
+        assertThat(captured.getExpireOn()).isEqualTo(EXPIRE_ON);
+        assertThat(captured.getPayload()).isEqualTo("payload");
+    }
+
+    @Test
+    void delete_propagatesFailoverStoreException() throws FailoverStoreException {
+        ReferentialPayload<String> original = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
+        doThrow(new FailoverStoreException("error", new RuntimeException())).when(delegate).delete(any());
+
+        assertThatThrownBy(() -> store.delete(original)).isInstanceOf(FailoverStoreException.class);
+    }
+
+    // --- find() ---
+
+    @Test
+    void find_presentResult_returnsWithUpToDateFalse() throws FailoverStoreException {
+        ReferentialPayload<String> found = new ReferentialPayload<>("name", "key", true, AS_OF, EXPIRE_ON, "payload");
+        when(delegate.find("name", "key")).thenReturn(Optional.of(found));
+
+        Optional<ReferentialPayload<String>> result = store.find("name", "key");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().isUpToDate()).isFalse();
+        assertThat(result.get().getName()).isEqualTo("name");
+        assertThat(result.get().getKey()).isEqualTo("key");
+        assertThat(result.get().getAsOf()).isEqualTo(AS_OF);
+        assertThat(result.get().getExpireOn()).isEqualTo(EXPIRE_ON);
+        assertThat(result.get().getPayload()).isEqualTo("payload");
+    }
+
+    @Test
+    void find_emptyResult_returnsEmpty() throws FailoverStoreException {
+        when(delegate.find("name", "key")).thenReturn(Optional.empty());
+
+        Optional<ReferentialPayload<String>> result = store.find("name", "key");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void find_propagatesFailoverStoreException() throws FailoverStoreException {
+        when(delegate.find("name", "key")).thenThrow(new FailoverStoreException("error", new RuntimeException()));
+
+        assertThatThrownBy(() -> store.find("name", "key")).isInstanceOf(FailoverStoreException.class);
+    }
+
+    // --- cleanByExpiry() ---
+
+    @Test
+    void cleanByExpiry_delegatesDirectly() throws FailoverStoreException {
+        LocalDateTime expiry = LocalDateTime.now();
+
+        store.cleanByExpiry(expiry);
+
+        verify(delegate).cleanByExpiry(expiry);
+    }
+
+    @Test
+    void cleanByExpiry_propagatesFailoverStoreException() throws FailoverStoreException {
+        LocalDateTime expiry = LocalDateTime.now();
+        doThrow(new FailoverStoreException("error", new RuntimeException())).when(delegate).cleanByExpiry(any());
+
+        assertThatThrownBy(() -> store.cleanByExpiry(expiry)).isInstanceOf(FailoverStoreException.class);
+    }
+}

--- a/failover-execution-resilience/src/test/java/com/societegenerale/failover/execution/resilience/MySpringBootTestApplication.java
+++ b/failover-execution-resilience/src/test/java/com/societegenerale/failover/execution/resilience/MySpringBootTestApplication.java
@@ -34,6 +34,7 @@ import com.societegenerale.failover.core.payload.PayloadEnricher;
 import com.societegenerale.failover.core.payload.RecoveredPayloadHandler;
 import com.societegenerale.failover.core.report.LoggerReportPublisher;
 import com.societegenerale.failover.core.report.ReportPublisher;
+import com.societegenerale.failover.core.store.DefaultFailoverStore;
 import com.societegenerale.failover.core.store.FailoverStore;
 import com.societegenerale.failover.store.FailoverStoreInmemory;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
@@ -60,7 +61,7 @@ public class MySpringBootTestApplication {
 
     @Bean
     public FailoverStore<Object> failoverStore() {
-        return new FailoverStoreInmemory<>();
+        return new DefaultFailoverStore<>(new FailoverStoreInmemory<>());
     }
 
     @Bean

--- a/failover-execution-resilience/src/test/java/com/societegenerale/failover/execution/resilience/ResilienceFailoverExecutionTest.java
+++ b/failover-execution-resilience/src/test/java/com/societegenerale/failover/execution/resilience/ResilienceFailoverExecutionTest.java
@@ -72,7 +72,7 @@ class ResilienceFailoverExecutionTest {
         assertThat(result.getAsOf()).isEqualTo(NOW);
 
         var optionalClientReferentialPayload = failoverStore.find("client-by-id", "1");
-        assertThat(optionalClientReferentialPayload).isPresent().contains(new ReferentialPayload<>("client-by-id", "1", true, NOW, NOW.plusHours(1), client));
+        assertThat(optionalClientReferentialPayload).isPresent().contains(new ReferentialPayload<>("client-by-id", "1", false, NOW, NOW.plusHours(1), client));
     }
 
     @Test

--- a/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverAutoConfiguration.java
+++ b/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverAutoConfiguration.java
@@ -55,12 +55,12 @@ import com.societegenerale.failover.core.report.manifest.ResourceLoader;
 import com.societegenerale.failover.core.scanner.DefaultFailoverScanner;
 import com.societegenerale.failover.core.scanner.FailoverScanner;
 import com.societegenerale.failover.core.store.FailoverStore;
+import com.societegenerale.failover.processor.FailoverStoreBeanPostProcessor;
 import com.societegenerale.failover.properties.FailoverProperties;
 import com.societegenerale.failover.properties.FailoverType;
 import com.societegenerale.failover.properties.StoreType;
 import com.societegenerale.failover.scheduler.ExpiryCleanupScheduler;
 import com.societegenerale.failover.scheduler.ReportScheduler;
-import com.societegenerale.failover.store.FailoverStoreAsync;
 import com.societegenerale.failover.store.FailoverStoreInmemory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -87,6 +87,11 @@ import java.util.List;
 @EnableAsync
 @EnableScheduling
 public class FailoverAutoConfiguration {
+
+    @Bean
+    public static FailoverStoreBeanPostProcessor failoverStoreBeanPostProcessor() {
+        return new FailoverStoreBeanPostProcessor();
+    }
 
     @ConditionalOnMissingBean
     @Bean
@@ -175,7 +180,7 @@ public class FailoverAutoConfiguration {
     @Bean
     public FailoverStore<Object> failoverStoreInmemory() {
         log.warn("FailoverStore configured to FailoverStoreInmemory. We highly recommend to 'NOT to USE' FailoverStoreInmemory in PRODUCTION. Available options are : {{}}", (Object) StoreType.values());
-        return new FailoverStoreAsync<>(new FailoverStoreInmemory<>());
+        return new FailoverStoreInmemory<>();
     }
 
     @ConditionalOnMissingBean

--- a/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverCaffeineStoreAutoConfiguration.java
+++ b/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverCaffeineStoreAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.societegenerale.failover.configuration;
 import com.societegenerale.failover.core.clock.FailoverClock;
 import com.societegenerale.failover.core.store.FailoverStore;
 import com.societegenerale.failover.properties.StoreType;
-import com.societegenerale.failover.store.FailoverStoreAsync;
 import com.societegenerale.failover.store.FailoverStoreCaffeine;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +40,6 @@ public class FailoverCaffeineStoreAutoConfiguration {
     @Bean
     public FailoverStore<Object> failoverStore(FailoverClock failoverClock) {
         log.warn("FailoverStore configured to FailoverStoreCaffeine. This will be based on caffeine cache and hence you will have some impact on heap for high volume failover storage. Available options are : {{}}", (Object) StoreType.values());
-        return new FailoverStoreAsync<>(new FailoverStoreCaffeine<>(failoverClock));
+        return new FailoverStoreCaffeine<>(failoverClock);
     }
 }

--- a/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverJdbcStoreAutoConfiguration.java
+++ b/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverJdbcStoreAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.societegenerale.failover.configuration;
 import tools.jackson.databind.ObjectMapper;
 import com.societegenerale.failover.core.store.FailoverStore;
 import com.societegenerale.failover.properties.FailoverProperties;
-import com.societegenerale.failover.store.FailoverStoreAsync;
 import com.societegenerale.failover.store.FailoverStoreJdbc;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +45,6 @@ public class FailoverJdbcStoreAutoConfiguration {
     @Bean
     public FailoverStore<Object> failoverStoreJdbc(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
         log.info("FailoverStore configured to FailoverStoreJdbc.");
-        return new FailoverStoreAsync<>(new FailoverStoreJdbc<>(failoverProperties.getStore().getJdbc().getTablePrefix(), jdbcTemplate, objectMapper));
+        return new FailoverStoreJdbc<>(failoverProperties.getStore().getJdbc().getTablePrefix(), jdbcTemplate, objectMapper);
     }
 }

--- a/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/processor/FailoverStoreBeanPostProcessor.java
+++ b/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/processor/FailoverStoreBeanPostProcessor.java
@@ -1,0 +1,23 @@
+package com.societegenerale.failover.processor;
+
+import com.societegenerale.failover.core.store.DefaultFailoverStore;
+import com.societegenerale.failover.core.store.FailoverStore;
+import com.societegenerale.failover.store.FailoverStoreAsync;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+public class FailoverStoreBeanPostProcessor implements BeanPostProcessor {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public @Nullable Object postProcessBeforeInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
+        if (bean instanceof FailoverStore
+                && !(bean instanceof FailoverStoreAsync)
+                && !(bean instanceof DefaultFailoverStore)) {
+            return new FailoverStoreAsync<>(new DefaultFailoverStore<>((FailoverStore<Object>) bean));
+        }
+        return bean;
+    }
+}

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverAutoConfigurationTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverAutoConfigurationTest.java
@@ -107,7 +107,7 @@ class FailoverAutoConfigurationTest {
 
     @Test
     @DisplayName("should execute store asynchronously on a different thread")
-    void store_executesOnDifferentThread() throws Exception {
+    void storeExecutesOnDifferentThread() throws Exception {
         String callingThread = Thread.currentThread().getName();
         AtomicReference<String> storingThread = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverAutoConfigurationTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverAutoConfigurationTest.java
@@ -19,6 +19,8 @@ package com.societegenerale.failover.configuration;
 import com.societegenerale.failover.MyTestApplication;
 import com.societegenerale.failover.aspect.FailoverAspect;
 import com.societegenerale.failover.core.BasicFailoverExecution;
+import com.societegenerale.failover.core.payload.ReferentialPayload;
+import com.societegenerale.failover.core.store.DefaultFailoverStore;
 import com.societegenerale.failover.core.store.FailoverStore;
 import com.societegenerale.failover.store.FailoverStoreAsync;
 import com.societegenerale.failover.store.FailoverStoreInmemory;
@@ -30,8 +32,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static com.societegenerale.failover.configuration.BeanAssertions.assertBasicBean;
 import static com.societegenerale.failover.configuration.BeanAssertions.assertBeansAreNotNull;
+import static com.societegenerale.failover.core.util.CastingUtils.cast;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -69,9 +80,89 @@ class FailoverAutoConfigurationTest {
     @DisplayName("should load inmemory failover store by default")
     void shouldLoadInmemoryFailoverStoreByDefault() throws Exception {
         assertThat(failoverStore).isNotNull();
-        if(AopUtils.isAopProxy(failoverStore) && failoverStore instanceof Advised advised) {
-            Object target = advised.getTargetSource().getTarget();
-            assertThat(((FailoverStoreAsync)target).getFailoverStore()).isInstanceOf(FailoverStoreInmemory.class);
+        Object target = AopUtils.isAopProxy(failoverStore)
+                ? ((Advised) failoverStore).getTargetSource().getTarget()
+                : failoverStore;
+        FailoverStoreAsync<Object> async = cast(target);
+        assertThat(async).isNotNull();
+        FailoverStore<Object> inner = requireNonNull(async.getFailoverStore());
+        assertThat(inner).isInstanceOf(DefaultFailoverStore.class);
+        assertThat(requireNonNull(((DefaultFailoverStore<Object>) inner).getFailoverStore())).isInstanceOf(FailoverStoreInmemory.class);
+    }
+
+    @Test
+    @DisplayName("should wrap async and default stores with the given inmemory failover store")
+    @SuppressWarnings("unchecked")
+    void shouldWrapAsyncAndDefaultStoresWithTheGivenInmemoryFailoverStore() throws Exception {
+        Object target = AopUtils.isAopProxy(failoverStore)
+                ? ((Advised) failoverStore).getTargetSource().getTarget()
+                : failoverStore;
+        assertThat(target).isNotNull();
+        assertThat(target).isInstanceOf(FailoverStoreAsync.class);
+        FailoverStore<Object> inner = requireNonNull(((FailoverStoreAsync<Object>) target).getFailoverStore());
+        assertThat(inner).isInstanceOf(DefaultFailoverStore.class);
+        FailoverStore<Object> innermost = requireNonNull(((DefaultFailoverStore<Object>) inner).getFailoverStore());
+        assertThat(innermost).isInstanceOf(FailoverStoreInmemory.class);
+    }
+
+    @Test
+    @DisplayName("should execute store asynchronously on a different thread")
+    void store_executesOnDifferentThread() throws Exception {
+        String callingThread = Thread.currentThread().getName();
+        AtomicReference<String> storingThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Unwrap: AOP proxy → FailoverStoreAsync → DefaultFailoverStore
+        Object target = ((Advised) failoverStore).getTargetSource().getTarget();
+        FailoverStoreAsync<Object> async = cast(target);
+        assertThat(async).isNotNull();
+        DefaultFailoverStore<Object> defaultStore = (DefaultFailoverStore<Object>) requireNonNull(async.getFailoverStore());
+        FailoverStore<Object> originalInner = requireNonNull(defaultStore.getFailoverStore());
+
+        // Inject thread-capturing wrapper via reflection
+        Field innerField = DefaultFailoverStore.class.getDeclaredField("failoverStore");
+        innerField.setAccessible(true);
+        innerField.set(defaultStore, new ThreadCapturingStore(originalInner, storingThread, latch));
+
+        try {
+            failoverStore.store(new ReferentialPayload<>("async-test", "key1", true,
+                    LocalDateTime.now(), LocalDateTime.now().plusHours(1), "payload"));
+
+            assertThat(latch.await(5, TimeUnit.SECONDS)).as("store() did not execute within 5 seconds").isTrue();
+            assertThat(storingThread.get())
+                    .as("store() must run on a thread different from the calling thread")
+                    .isNotEqualTo(callingThread);
+        } finally {
+            innerField.set(defaultStore, originalInner);
+        }
+    }
+
+    private record ThreadCapturingStore(
+            FailoverStore<Object> delegate,
+            AtomicReference<String> threadCapture,
+            CountDownLatch latch
+    ) implements FailoverStore<Object> {
+
+        @Override
+        public void store(ReferentialPayload<Object> payload) {
+            threadCapture.set(Thread.currentThread().getName());
+            latch.countDown();
+            delegate.store(payload);
+        }
+
+        @Override
+        public void delete(ReferentialPayload<Object> payload) {
+            delegate.delete(payload);
+        }
+
+        @Override
+        public Optional<ReferentialPayload<Object>> find(String name, String key) {
+            return delegate.find(name, key);
+        }
+
+        @Override
+        public void cleanByExpiry(LocalDateTime expiry) {
+            delegate.cleanByExpiry(expiry);
         }
     }
 }

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverAutoConfigurationTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverAutoConfigurationTest.java
@@ -26,6 +26,7 @@ import com.societegenerale.failover.store.FailoverStoreAsync;
 import com.societegenerale.failover.store.FailoverStoreInmemory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ReflectionUtils;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -121,7 +122,7 @@ class FailoverAutoConfigurationTest {
 
         // Inject thread-capturing wrapper via reflection
         Field innerField = DefaultFailoverStore.class.getDeclaredField("failoverStore");
-        innerField.setAccessible(true);
+        ReflectionUtils.makeAccessible(innerField);
         innerField.set(defaultStore, new ThreadCapturingStore(originalInner, storingThread, latch));
 
         try {

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverCaffeineStoreAutoConfigurationTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverCaffeineStoreAutoConfigurationTest.java
@@ -17,6 +17,7 @@
 package com.societegenerale.failover.configuration;
 
 import com.societegenerale.failover.MyTestApplication;
+import com.societegenerale.failover.core.store.DefaultFailoverStore;
 import com.societegenerale.failover.core.store.FailoverStore;
 import com.societegenerale.failover.store.FailoverStoreAsync;
 import com.societegenerale.failover.store.FailoverStoreCaffeine;
@@ -30,6 +31,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.TestPropertySource;
 
 import static com.societegenerale.failover.configuration.BeanAssertions.assertBasicBean;
+import static com.societegenerale.failover.core.util.CastingUtils.cast;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -55,9 +58,28 @@ class FailoverCaffeineStoreAutoConfigurationTest {
     @DisplayName("should load caffeine failover store bean")
     void shouldLoadCaffeineFailoverStoreBean() throws Exception {
         assertThat(failoverStore).isNotNull();
-        if(AopUtils.isAopProxy(failoverStore) && failoverStore instanceof Advised advised) {
-            Object target = advised.getTargetSource().getTarget();
-            assertThat(((FailoverStoreAsync)target).getFailoverStore()).isInstanceOf(FailoverStoreCaffeine.class);
-        }
+        Object target = AopUtils.isAopProxy(failoverStore)
+                ? ((Advised) failoverStore).getTargetSource().getTarget()
+                : failoverStore;
+        FailoverStoreAsync<Object> async = cast(target);
+        assertThat(async).isNotNull();
+        FailoverStore<Object> inner = requireNonNull(async.getFailoverStore());
+        assertThat(inner).isInstanceOf(DefaultFailoverStore.class);
+        assertThat(requireNonNull(((DefaultFailoverStore<Object>) inner).getFailoverStore())).isInstanceOf(FailoverStoreCaffeine.class);
+    }
+
+    @Test
+    @DisplayName("should wrap async and default stores with the given failover store caffeine")
+    @SuppressWarnings("unchecked")
+    void shouldWrapAsyncAndDefaultStoresWithTheGivenFailoverStoreCaffeine() throws Exception {
+        Object target = AopUtils.isAopProxy(failoverStore)
+                ? ((Advised) failoverStore).getTargetSource().getTarget()
+                : failoverStore;
+        assertThat(target).isNotNull();
+        assertThat(target).isInstanceOf(FailoverStoreAsync.class);
+        FailoverStore<Object> inner = requireNonNull(((FailoverStoreAsync<Object>) target).getFailoverStore());
+        assertThat(inner).isInstanceOf(DefaultFailoverStore.class);
+        FailoverStore<Object> innermost = requireNonNull(((DefaultFailoverStore<Object>) inner).getFailoverStore());
+        assertThat(innermost).isInstanceOf(FailoverStoreCaffeine.class);
     }
 }

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverJdbcStoreAutoConfigurationTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverJdbcStoreAutoConfigurationTest.java
@@ -17,6 +17,7 @@
 package com.societegenerale.failover.configuration;
 
 import com.societegenerale.failover.MyTestApplication;
+import com.societegenerale.failover.core.store.DefaultFailoverStore;
 import com.societegenerale.failover.core.store.FailoverStore;
 import com.societegenerale.failover.store.FailoverStoreAsync;
 import com.societegenerale.failover.store.FailoverStoreJdbc;
@@ -30,6 +31,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.TestPropertySource;
 
 import static com.societegenerale.failover.configuration.BeanAssertions.assertBasicBean;
+import static com.societegenerale.failover.core.util.CastingUtils.cast;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -53,11 +56,30 @@ class FailoverJdbcStoreAutoConfigurationTest {
 
     @Test
     @DisplayName("should load jdbc failover store bean")
-    void shouldLoadInmemoryFailoverStoreBean() throws Exception {
+    void shouldLoadJdbcFailoverStoreBean() throws Exception {
         assertThat(failoverStore).isNotNull();
-        if(AopUtils.isAopProxy(failoverStore) && failoverStore instanceof Advised advised) {
-            Object target = advised.getTargetSource().getTarget();
-            assertThat(((FailoverStoreAsync)target).getFailoverStore()).isInstanceOf(FailoverStoreJdbc.class);
-        }
+        Object target = AopUtils.isAopProxy(failoverStore)
+                ? ((Advised) failoverStore).getTargetSource().getTarget()
+                : failoverStore;
+        FailoverStoreAsync<Object> async = cast(target);
+        assertThat(async).isNotNull();
+        FailoverStore<Object> inner = requireNonNull(async.getFailoverStore());
+        assertThat(inner).isInstanceOf(DefaultFailoverStore.class);
+        assertThat(requireNonNull(((DefaultFailoverStore<Object>) inner).getFailoverStore())).isInstanceOf(FailoverStoreJdbc.class);
+    }
+
+    @Test
+    @DisplayName("should wrap async and default stores with the given failover store jdbc")
+    @SuppressWarnings("unchecked")
+    void shouldWrapAsyncAndDefaultStoresWithTheGivenFailoverStoreJdbc() throws Exception {
+        Object target = AopUtils.isAopProxy(failoverStore)
+                ? ((Advised) failoverStore).getTargetSource().getTarget()
+                : failoverStore;
+        assertThat(target).isNotNull();
+        assertThat(target).isInstanceOf(FailoverStoreAsync.class);
+        FailoverStore<Object> inner = requireNonNull(((FailoverStoreAsync<Object>) target).getFailoverStore());
+        assertThat(inner).isInstanceOf(DefaultFailoverStore.class);
+        FailoverStore<Object> innermost = requireNonNull(((DefaultFailoverStore<Object>) inner).getFailoverStore());
+        assertThat(innermost).isInstanceOf(FailoverStoreJdbc.class);
     }
 }

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/processor/FailoverStoreBeanPostProcessorTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/processor/FailoverStoreBeanPostProcessorTest.java
@@ -23,7 +23,7 @@ class FailoverStoreBeanPostProcessorTest {
     @Test
     @DisplayName("should wrap raw FailoverStore with FailoverStoreAsync and DefaultFailoverStore")
     @SuppressWarnings("unchecked")
-    void rawFailoverStore_wrapsWithAsyncAndDefault() {
+    void rawFailoverStoreWrapsWithAsyncAndDefault() {
         FailoverStoreInmemory<Object> rawStore = new FailoverStoreInmemory<>();
 
         Object result = processor.postProcessBeforeInitialization(rawStore, "failoverStore");
@@ -36,7 +36,7 @@ class FailoverStoreBeanPostProcessorTest {
     @Test
     @DisplayName("should preserve original bean as the innermost store after wrapping")
     @SuppressWarnings("unchecked")
-    void rawFailoverStore_innermostIsOriginalBean() {
+    void rawFailoverStoreInnermostIsOriginalBean() {
         FailoverStoreInmemory<Object> rawStore = new FailoverStoreInmemory<>();
 
         Object result = processor.postProcessBeforeInitialization(rawStore, "failoverStore");
@@ -48,7 +48,7 @@ class FailoverStoreBeanPostProcessorTest {
 
     @Test
     @DisplayName("should return FailoverStoreAsync as-is without double-wrapping")
-    void alreadyWrappedWithAsync_returnsSameInstance() {
+    void alreadyWrappedWithAsyncReturnsSameInstance() {
         FailoverStoreAsync<Object> asyncStore = new FailoverStoreAsync<>(new FailoverStoreInmemory<>());
 
         Object result = processor.postProcessBeforeInitialization(asyncStore, "failoverStoreAsync");
@@ -58,7 +58,7 @@ class FailoverStoreBeanPostProcessorTest {
 
     @Test
     @DisplayName("should return DefaultFailoverStore as-is without double-wrapping")
-    void alreadyWrappedWithDefault_returnsSameInstance() {
+    void alreadyWrappedWithDefaultReturnsSameInstance() {
         DefaultFailoverStore<Object> defaultStore = new DefaultFailoverStore<>(new FailoverStoreInmemory<>());
 
         Object result = processor.postProcessBeforeInitialization(defaultStore, "defaultFailoverStore");
@@ -68,7 +68,7 @@ class FailoverStoreBeanPostProcessorTest {
 
     @Test
     @DisplayName("should return non-FailoverStore bean unchanged")
-    void nonFailoverStoreBean_returnsSameInstance() {
+    void nonFailoverStoreBeanReturnsSameInstance() {
         String nonStoreBean = "someBean";
 
         Object result = processor.postProcessBeforeInitialization(nonStoreBean, "someBean");
@@ -78,7 +78,7 @@ class FailoverStoreBeanPostProcessorTest {
 
     @Test
     @DisplayName("should return arbitrary object bean unchanged")
-    void arbitraryObject_returnsSameInstance() {
+    void arbitraryObjectReturnsSameInstance() {
         Object arbitraryBean = new Object();
 
         Object result = processor.postProcessBeforeInitialization(arbitraryBean, "arbitraryBean");
@@ -89,7 +89,7 @@ class FailoverStoreBeanPostProcessorTest {
     @Test
     @DisplayName("should wrap regardless of bean name")
     @SuppressWarnings("unchecked")
-    void rawFailoverStore_wrapsRegardlessOfBeanName() {
+    void rawFailoverStoreWrapsRegardlessOfBeanName() {
         FailoverStoreInmemory<Object> rawStore = new FailoverStoreInmemory<>();
 
         Object result = processor.postProcessBeforeInitialization(rawStore, "anyBeanNameWhatsoever");

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/processor/FailoverStoreBeanPostProcessorTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/processor/FailoverStoreBeanPostProcessorTest.java
@@ -1,0 +1,102 @@
+package com.societegenerale.failover.processor;
+
+import com.societegenerale.failover.core.store.DefaultFailoverStore;
+import com.societegenerale.failover.core.store.FailoverStore;
+import com.societegenerale.failover.store.FailoverStoreAsync;
+import com.societegenerale.failover.store.FailoverStoreInmemory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FailoverStoreBeanPostProcessorTest {
+
+    private FailoverStoreBeanPostProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new FailoverStoreBeanPostProcessor();
+    }
+
+    @Test
+    @DisplayName("should wrap raw FailoverStore with FailoverStoreAsync and DefaultFailoverStore")
+    @SuppressWarnings("unchecked")
+    void rawFailoverStore_wrapsWithAsyncAndDefault() {
+        FailoverStoreInmemory<Object> rawStore = new FailoverStoreInmemory<>();
+
+        Object result = processor.postProcessBeforeInitialization(rawStore, "failoverStore");
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(FailoverStoreAsync.class);
+        FailoverStore<Object> inner = requireNonNull(((FailoverStoreAsync<Object>) result).getFailoverStore());
+        assertThat(inner).isInstanceOf(DefaultFailoverStore.class);
+    }
+
+    @Test
+    @DisplayName("should preserve original bean as the innermost store after wrapping")
+    @SuppressWarnings("unchecked")
+    void rawFailoverStore_innermostIsOriginalBean() {
+        FailoverStoreInmemory<Object> rawStore = new FailoverStoreInmemory<>();
+
+        Object result = processor.postProcessBeforeInitialization(rawStore, "failoverStore");
+        assertThat(result).isNotNull();
+        FailoverStoreAsync<Object> async = (FailoverStoreAsync<Object>) result;
+        DefaultFailoverStore<Object> defaultStore = (DefaultFailoverStore<Object>) requireNonNull(async.getFailoverStore());
+        assertThat(requireNonNull(defaultStore.getFailoverStore())).isSameAs(rawStore);
+    }
+
+    @Test
+    @DisplayName("should return FailoverStoreAsync as-is without double-wrapping")
+    void alreadyWrappedWithAsync_returnsSameInstance() {
+        FailoverStoreAsync<Object> asyncStore = new FailoverStoreAsync<>(new FailoverStoreInmemory<>());
+
+        Object result = processor.postProcessBeforeInitialization(asyncStore, "failoverStoreAsync");
+
+        assertThat(result).isSameAs(asyncStore);
+    }
+
+    @Test
+    @DisplayName("should return DefaultFailoverStore as-is without double-wrapping")
+    void alreadyWrappedWithDefault_returnsSameInstance() {
+        DefaultFailoverStore<Object> defaultStore = new DefaultFailoverStore<>(new FailoverStoreInmemory<>());
+
+        Object result = processor.postProcessBeforeInitialization(defaultStore, "defaultFailoverStore");
+
+        assertThat(result).isSameAs(defaultStore);
+    }
+
+    @Test
+    @DisplayName("should return non-FailoverStore bean unchanged")
+    void nonFailoverStoreBean_returnsSameInstance() {
+        String nonStoreBean = "someBean";
+
+        Object result = processor.postProcessBeforeInitialization(nonStoreBean, "someBean");
+
+        assertThat(result).isSameAs(nonStoreBean);
+    }
+
+    @Test
+    @DisplayName("should return arbitrary object bean unchanged")
+    void arbitraryObject_returnsSameInstance() {
+        Object arbitraryBean = new Object();
+
+        Object result = processor.postProcessBeforeInitialization(arbitraryBean, "arbitraryBean");
+
+        assertThat(result).isSameAs(arbitraryBean);
+    }
+
+    @Test
+    @DisplayName("should wrap regardless of bean name")
+    @SuppressWarnings("unchecked")
+    void rawFailoverStore_wrapsRegardlessOfBeanName() {
+        FailoverStoreInmemory<Object> rawStore = new FailoverStoreInmemory<>();
+
+        Object result = processor.postProcessBeforeInitialization(rawStore, "anyBeanNameWhatsoever");
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(FailoverStoreAsync.class);
+        FailoverStore<Object> inner = requireNonNull(((FailoverStoreAsync<Object>) result).getFailoverStore());
+        assertThat(inner).isInstanceOf(DefaultFailoverStore.class);
+        assertThat(requireNonNull(((DefaultFailoverStore<Object>) inner).getFailoverStore())).isSameAs(rawStore);
+    }
+}

--- a/failover-store-caffeine/src/main/java/com/societegenerale/failover/store/FailoverStoreCaffeine.java
+++ b/failover-store-caffeine/src/main/java/com/societegenerale/failover/store/FailoverStoreCaffeine.java
@@ -34,6 +34,19 @@ import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 
 /**
+ * {@link FailoverStore} implementation backed by Caffeine in-memory caches.
+ *
+ * <p>Each referential name gets its own {@link Cache} instance, created on first write and
+ * configured with {@code expireAfterWrite} set to the duration from the current clock time to
+ * the payload's {@code expireOn} timestamp. Caffeine handles eviction automatically, so
+ * {@link #cleanByExpiry} is a no-op.
+ *
+ * <p>All reads and writes operate on defensive copies of {@link ReferentialPayload} to prevent
+ * callers from mutating cached state.
+ *
+ * <p>Cache keys use the composite format {@code name##key}.
+ *
+ * @param <T> the type of the business payload
  * @author Anand Manissery
  */
 @AllArgsConstructor
@@ -44,33 +57,71 @@ public class FailoverStoreCaffeine<T> implements FailoverStore<T> {
 
     private final FailoverClock failoverClock;
 
+    /**
+     * Stores a defensive copy of the payload in the Caffeine cache for its referential name.
+     *
+     * <p>If no cache exists for the given name, one is created with {@code expireAfterWrite}
+     * computed as the duration from now to {@code referentialPayload.getExpireOn()}.
+     *
+     * @param referentialPayload the payload to cache; must not be {@code null}
+     */
     @Override
     public void store(ReferentialPayload<T> referentialPayload) {
-        var cache = store.computeIfAbsent(referentialPayload.getName(),
-                _ -> Caffeine.newBuilder().expireAfterWrite(Duration.between(failoverClock.now(), referentialPayload.getExpireOn())).build());
-        cache.put(storeKey(referentialPayload.getName(), referentialPayload.getKey()), referentialPayload);
+        var payload = referentialPayload.copy();
+        var cache = store.computeIfAbsent(payload.getName(),
+                _ -> Caffeine.newBuilder().expireAfterWrite(Duration.between(failoverClock.now(), payload.getExpireOn())).build());
+        cache.put(storeKey(payload.getName(), payload.getKey()), payload);
     }
 
+    /**
+     * Invalidates the cache entry for the given payload, if the referential cache exists.
+     *
+     * <p>A no-op if no cache has been created for the payload's referential name.
+     *
+     * @param referentialPayload the payload to remove; must not be {@code null}
+     */
     @Override
     public void delete(ReferentialPayload<T> referentialPayload) {
-        if(store.containsKey(referentialPayload.getName())) {
+        if (store.containsKey(referentialPayload.getName())) {
             store.get(referentialPayload.getName()).invalidate(storeKey(referentialPayload.getName(), referentialPayload.getKey()));
         }
     }
 
+    /**
+     * Looks up a payload by name and key, returning a defensive copy if found.
+     *
+     * <p>Returns {@link Optional#empty()} if no cache exists for the given name or if the
+     * entry has been evicted by Caffeine.
+     *
+     * @param name the referential name
+     * @param key  the unique key within that referential
+     * @return an {@link Optional} containing a copy of the cached payload, or empty if not found
+     */
     @Override
     public Optional<ReferentialPayload<T>> find(String name, String key) {
-        if(store.containsKey(name)) {
-            return ofNullable(store.get(name).get(storeKey(name, key), _ -> null));
+        if (store.containsKey(name)) {
+            return ofNullable(store.get(name).get(storeKey(name, key), _ -> null)).map(ReferentialPayload::copy);
         }
         return empty();
     }
 
+    /**
+     * No-op: expiry is managed automatically by Caffeine's {@code expireAfterWrite} policy.
+     *
+     * @param expiry ignored
+     */
     @Override
     public void cleanByExpiry(LocalDateTime expiry) {
         log.debug("Ignoring the clean up as the expiry is already managed by Caffeine Cache with 'expireAfterWrite'");
     }
 
+    /**
+     * Builds a composite cache key from the referential name and entry key.
+     *
+     * @param name the referential name
+     * @param key  the entry key
+     * @return composite key in the form {@code name##key}
+     */
     private String storeKey(String name, String key) {
         return name + "##" + key;
     }

--- a/failover-store-inmemory/src/main/java/com/societegenerale/failover/store/FailoverStoreInmemory.java
+++ b/failover-store-inmemory/src/main/java/com/societegenerale/failover/store/FailoverStoreInmemory.java
@@ -43,7 +43,7 @@ public class FailoverStoreInmemory<T> implements FailoverStore<T> {
 
     @Override
     public Optional<ReferentialPayload<T>> find(String name, String key) {
-        return Optional.ofNullable(store.get(storeKey(name, key)));
+        return Optional.ofNullable(copy(store.get(storeKey(name, key))));
     }
 
     @Override
@@ -53,5 +53,9 @@ public class FailoverStoreInmemory<T> implements FailoverStore<T> {
 
     private String storeKey(String name, String key) {
         return name + "##" + key;
+    }
+
+    protected ReferentialPayload<T> copy(ReferentialPayload<T> rPayload) {
+        return new ReferentialPayload<>(rPayload.getName(), rPayload.getKey(), rPayload.isUpToDate(), rPayload.getAsOf(), rPayload.getExpireOn(), rPayload.getPayload());
     }
 }

--- a/failover-store-inmemory/src/main/java/com/societegenerale/failover/store/FailoverStoreInmemory.java
+++ b/failover-store-inmemory/src/main/java/com/societegenerale/failover/store/FailoverStoreInmemory.java
@@ -25,37 +25,79 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
+ * {@link FailoverStore} implementation backed by a plain {@link ConcurrentHashMap}.
+ *
+ * <p>Suitable for single-node, non-persistent failover caching where simplicity is preferred
+ * over advanced eviction policies. Entries are evicted explicitly via {@link #cleanByExpiry},
+ * which removes all entries whose {@code expireOn} timestamp is strictly before the given cutoff.
+ *
+ * <p>All reads and writes operate on defensive copies of {@link ReferentialPayload} to prevent
+ * callers from mutating stored state.
+ *
+ * <p>Cache keys use the composite format {@code name##key}.
+ *
+ * @param <T> the type of the business payload
  * @author Anand Manissery
  */
 public class FailoverStoreInmemory<T> implements FailoverStore<T> {
 
     private final Map<String, ReferentialPayload<T>> store = new ConcurrentHashMap<>();
 
+    /**
+     * Stores a defensive copy of the payload, keyed by its referential name and key.
+     *
+     * <p>An existing entry for the same ({@code name}, {@code key}) pair is overwritten.
+     *
+     * @param referentialPayload the payload to store; must not be {@code null}
+     */
     @Override
     public void store(ReferentialPayload<T> referentialPayload) {
-        store.put(storeKey(referentialPayload.getName(), referentialPayload.getKey()), referentialPayload);
+        var payload = referentialPayload.copy();
+        store.put(storeKey(payload.getName(), payload.getKey()), payload);
     }
 
+    /**
+     * Removes the entry for the given payload's ({@code name}, {@code key}) pair.
+     *
+     * <p>A no-op if no entry exists for that pair.
+     *
+     * @param referentialPayload the payload to remove; must not be {@code null}
+     */
     @Override
     public void delete(ReferentialPayload<T> referentialPayload) {
         store.remove(storeKey(referentialPayload.getName(), referentialPayload.getKey()));
     }
 
+    /**
+     * Looks up a payload by name and key, returning a defensive copy if found.
+     *
+     * @param name the referential name
+     * @param key  the unique key within that referential
+     * @return an {@link Optional} containing a copy of the stored payload, or empty if not found
+     */
     @Override
     public Optional<ReferentialPayload<T>> find(String name, String key) {
-        return Optional.ofNullable(copy(store.get(storeKey(name, key))));
+        return Optional.ofNullable(store.get(storeKey(name, key))).map(ReferentialPayload::copy);
     }
 
+    /**
+     * Evicts all entries whose {@code expireOn} timestamp is strictly before the given cutoff.
+     *
+     * @param expiry the cutoff datetime; entries with {@code expireOn} before this value are removed
+     */
     @Override
     public void cleanByExpiry(LocalDateTime expiry) {
         store.entrySet().removeIf(entry -> expiry.isAfter(entry.getValue().getExpireOn()));
     }
 
+    /**
+     * Builds a composite store key from the referential name and entry key.
+     *
+     * @param name the referential name
+     * @param key  the entry key
+     * @return composite key in the form {@code name##key}
+     */
     private String storeKey(String name, String key) {
         return name + "##" + key;
-    }
-
-    protected ReferentialPayload<T> copy(ReferentialPayload<T> rPayload) {
-        return new ReferentialPayload<>(rPayload.getName(), rPayload.getKey(), rPayload.isUpToDate(), rPayload.getAsOf(), rPayload.getExpireOn(), rPayload.getPayload());
     }
 }

--- a/failover-store-inmemory/src/test/java/com/societegenerale/failover/store/FailoverStoreInmemoryTest.java
+++ b/failover-store-inmemory/src/test/java/com/societegenerale/failover/store/FailoverStoreInmemoryTest.java
@@ -84,7 +84,7 @@ class FailoverStoreInmemoryTest {
 
         failoverStoreInmemory.cleanByExpiry(NOW.plusMinutes(4));
 
-        assertThat(failoverStoreInmemory.find("third-party-failover", "1")).isNotPresent();
+        assertThat(failoverStoreInmemory.find("third-party-failover", "1")).isEmpty();
         assertThat(failoverStoreInmemory.find("third-party-failover", "2")).isNotPresent();
         assertThat(failoverStoreInmemory.find("third-party-failover", "3")).isNotPresent();
         var result = failoverStoreInmemory.find("third-party-failover", "4");


### PR DESCRIPTION
## Summary
### Mutable stored object in `FailoverStoreInmemory`

**File:** `failover-store-inmemory/src/main/java/com/societegenerale/failover/store/FailoverStoreInmemory.java:46`  
`DefaultFailoverHandler.recover()` calls `referentialPayload.setUpToDate(false)` on the object returned by `find()`. For in-memory store, `find()` returns the same reference that is stored in the `ConcurrentHashMap`. This permanently mutates the cached entry: subsequent `find()` calls will always return `upToDate=false` even before recovery is needed.

**Fix:** Return a defensive copy in `find()`.

## Details
<!-- Describe your changes in detail and the context -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR
- [x] I have verified all the modules and confirmed no impacts

## Related issue : 
<!-- If it fixes an open issue, please link to the issue here. -->