### PR TITLE
fix: order Micrometer metrics/tracing autoconfigs after Boot's; clean…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - ALWAYS query the knowledge graph first.
 - Only read raw files if explicitly asked.
-- Use graphify-out/wiki/index.md as your entry point.
+- Use graphify-out/GRAPH_REPORT.md as your entry point.
 
 ## Build and test commands
 

--- a/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverAutoConfiguration.java
+++ b/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverAutoConfiguration.java
@@ -219,26 +219,34 @@ public class FailoverAutoConfiguration {
     }
 
     /**
-     * Composes the active {@link ContextPropagator} from available propagator beans:
+     * Composes the active {@link ContextPropagator} from <em>every</em> {@link ContextPropagator}
+     * bean in the application context, plus an always-on {@link MdcContextPropagator}:
      * <ol>
-     *   <li>{@link TenantContextPropagator} — present when {@code failover.store.multitenant.enabled=true}</li>
-     *   <li>{@link MicrometerContextPropagator} — present when {@code io.micrometer.tracing.Tracer} is on classpath and a {@code Tracer} bean exists</li>
-     *   <li>{@link MdcContextPropagator} — always included</li>
+     *   <li>All {@code ContextPropagator} beans, gathered in
+     *       {@link ObjectProvider#orderedStream() ordered} form. This includes the auto-configured
+     *       {@link TenantContextPropagator} (when {@code failover.store.multitenant.enabled=true})
+     *       and {@link MicrometerContextPropagator} (when {@code io.micrometer.tracing.Tracer} is on
+     *       the classpath and a {@code Tracer} bean exists), <em>and any custom {@code ContextPropagator}
+     *       bean you declare</em>. Annotate a custom bean with {@code @Order} to control its position
+     *       in the chain.</li>
+     *   <li>{@link MdcContextPropagator} — always appended last (innermost: restored immediately
+     *       before the slice runs).</li>
      * </ol>
-     * Declare your own {@code ContextPropagator} bean to replace this composition entirely.
+     * Declare a bean <strong>named {@code contextPropagator}</strong> to replace this composition
+     * entirely; declare any other {@code ContextPropagator} bean to <strong>add</strong> it to the chain.
      *
-     * @param tenantPropagatorProvider    optional {@link TenantContextPropagator} bean
-     * @param micrometerPropagatorProvider optional {@link MicrometerContextPropagator} bean
+     * <p>The parameter is a {@link List} (not an {@code ObjectProvider}) on purpose: Spring's
+     * collection injection excludes the bean currently in creation, so this {@code contextPropagator}
+     * bean does not gather itself (which would be a self-referential {@code BeanCurrentlyInCreationException}).
+     * The list is ordered by {@code @Order}/{@link org.springframework.core.Ordered}.
+     *
+     * @param contextPropagators all {@link ContextPropagator} beans in the context (self excluded), {@code @Order}-sorted
      * @return a single propagator or a {@link CompositeContextPropagator} when multiple are present
      */
     @ConditionalOnMissingBean(name = "contextPropagator")
     @Bean
-    public ContextPropagator contextPropagator(
-            ObjectProvider<TenantContextPropagator> tenantPropagatorProvider,
-            ObjectProvider<MicrometerContextPropagator> micrometerPropagatorProvider) {
-        List<ContextPropagator> propagators = new ArrayList<>();
-        tenantPropagatorProvider.ifAvailable(propagators::add);
-        micrometerPropagatorProvider.ifAvailable(propagators::add);
+    public ContextPropagator contextPropagator(List<ContextPropagator> contextPropagators) {
+        List<ContextPropagator> propagators = new ArrayList<>(contextPropagators);
         propagators.add(new MdcContextPropagator());
         return propagators.size() == 1
                 ? propagators.getFirst()

--- a/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverAutoConfiguration.java
+++ b/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverAutoConfiguration.java
@@ -82,10 +82,9 @@ import java.util.List;
  * enricher, recovered-payload handler, method-exception policy, schedulers, and the
  * in-memory store factory (when no other store type is configured).
  *
- * <p>Store-type-specific beans (Caffeine, JDBC) are registered by their own
- * auto-configurations ({@code FailoverCaffeineStoreAutoConfiguration},
- * {@code FailoverJdbcStoreAutoConfiguration}). The final assembled {@code FailoverStore}
- * bean is produced by {@code FailoverStoreAutoConfiguration}.
+ * <p>Store-type-specific beans (Caffeine, JDBC) and the final assembled {@code FailoverStore}
+ * bean are produced by {@code FailoverStoreAutoConfiguration} (with per-tenant routing layered on
+ * by {@code FailoverStoreMultiTenantAutoConfiguration} when enabled).
  *
  * <p><strong>Note on structure:</strong> the core beans are declared flat on this class (rather
  * than grouped into nested {@code @Configuration} classes) on purpose. {@code @ConditionalOnMissingBean}

--- a/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverMicrometerAutoConfiguration.java
+++ b/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/FailoverMicrometerAutoConfiguration.java
@@ -33,9 +33,18 @@ import org.springframework.context.annotation.Bean;
  * Autoconfiguration for Micrometer-based failover metrics.
  *
  * <p>Active only when a {@link MeterRegistry} bean is present in the application context.
- * {@code @ConditionalOnBean(MeterRegistry.class)} is evaluated at the outer autoconfiguration
- * class level — guaranteeing it runs after all user bean definitions are loaded, making it
- * visible to beans from any configuration class (including test configurations).
+ *
+ * <p><strong>Ordering is critical.</strong> The {@link MeterRegistry} this autoconfiguration
+ * depends on is itself contributed by Spring Boot's own metrics autoconfigurations
+ * ({@code CompositeMeterRegistryAutoConfiguration}, {@code SimpleMetricsExportAutoConfiguration},
+ * and the registry-specific exporters). Because {@code @ConditionalOnBean} only sees beans that
+ * were registered by autoconfigurations evaluated <em>before</em> this one, this class must be
+ * ordered <em>after</em> those metrics autoconfigurations — otherwise {@code MeterRegistry} does
+ * not yet exist when the condition is evaluated, the condition fails, and the application silently
+ * falls back to {@code MdcLoggerObservablePublisher} only (no Micrometer metrics). This mirrors how
+ * Spring Boot's own meter-binder autoconfigurations (e.g. {@code JvmMetricsAutoConfiguration}) are
+ * ordered. The metrics autoconfigurations are referenced by name via {@code afterName} so this
+ * module needs no compile-time dependency on the Boot metrics-autoconfigure artifact.
  *
  * <p>The class-level {@code @ConditionalOnClass(name = ...)} uses the string form so that
  * Spring Boot's ASM reader evaluates the condition without loading the class into the JVM.
@@ -44,7 +53,13 @@ import org.springframework.context.annotation.Bean;
  *
  * @author Anand Manissery
  */
-@AutoConfiguration(after = FailoverAutoConfiguration.class)
+@AutoConfiguration(
+        after = FailoverAutoConfiguration.class,
+        afterName = {
+                "org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration",
+                "org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration",
+                "org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration"
+        })
 @ConditionalOnExpression("${failover.enabled:true} eq true")
 @ConditionalOnClass(name = "io.micrometer.core.instrument.MeterRegistry")
 @ConditionalOnBean(MeterRegistry.class)

--- a/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/MicrometerTracingAutoConfiguration.java
+++ b/failover-spring-boot-autoconfigure/src/main/java/com/societegenerale/failover/configuration/MicrometerTracingAutoConfiguration.java
@@ -38,11 +38,27 @@ import org.springframework.context.annotation.Bean;
  * via {@code ObjectProvider} and composed into the active
  * {@link com.societegenerale.failover.core.propagator.ContextPropagator}.
  *
+ * <p><strong>Ordering is critical.</strong> The {@link Tracer} this autoconfiguration gates on
+ * ({@code @ConditionalOnBean(Tracer.class)}) is contributed by Spring Boot's own tracing
+ * autoconfigurations (Brave / OpenTelemetry). Because {@code @ConditionalOnBean} only sees beans
+ * registered by autoconfigurations evaluated <em>before</em> this one, this class must be ordered
+ * <em>after</em> them — otherwise the {@code Tracer} does not yet exist when the condition is
+ * evaluated, the bean silently backs off, and scatter/gather slices lose span propagation with no
+ * error. They are referenced by name via {@code afterName} so this module needs no compile-time
+ * dependency on the Boot tracing-autoconfigure artifacts (and the OpenTelemetry name is a harmless
+ * no-op when that implementation is absent).
+ *
  * @author Anand Manissery
  * @see MicrometerContextPropagator
  * @see FailoverAutoConfiguration
  */
-@AutoConfiguration(after = FailoverAutoConfiguration.class)
+@AutoConfiguration(
+        after = FailoverAutoConfiguration.class,
+        afterName = {
+                "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration",
+                "org.springframework.boot.micrometer.tracing.brave.autoconfigure.BraveAutoConfiguration",
+                "org.springframework.boot.micrometer.tracing.otel.autoconfigure.OpenTelemetryTracingAutoConfiguration"
+        })
 @ConditionalOnClass(name = "io.micrometer.tracing.Tracer")
 @Slf4j
 public class MicrometerTracingAutoConfiguration {

--- a/failover-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/failover-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,11 +1,3 @@
-# Auto Configure
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.societegenerale.failover.configuration.FailoverAutoConfiguration,\
-com.societegenerale.failover.configuration.FailoverCaffeineStoreAutoConfiguration,\
-com.societegenerale.failover.configuration.FailoverJdbcStoreAutoConfiguration,\
-com.societegenerale.failover.configuration.MicrometerTracingAutoConfiguration,\
-com.societegenerale.failover.configuration.ResilienceFailoverExecutionAutoConfiguration
-
 # Failure Analyzer
 org.springframework.boot.diagnostics.FailureAnalyzer=\
 com.societegenerale.failover.analyzer.FailoverFailureAnalyzer

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverAutoConfigurationTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverAutoConfigurationTest.java
@@ -73,6 +73,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.societegenerale.failover.configuration.BeanAssertions.assertBasicBean;
@@ -505,6 +506,49 @@ class FailoverAutoConfigurationTest {
         @Bean
         public ContextPropagator contextPropagator() {
             return new StubPropagator();
+        }
+    }
+
+    // ── Custom (differently-named) ContextPropagator joins the composed chain ─
+
+    @Nested
+    @SpringBootTest(classes = {MyTestApplication.class, FailoverAutoConfigurationTest.CustomNamedPropagatorConfig.class})
+    @DisplayName("when a custom, differently-named ContextPropagator bean is present")
+    class WhenCustomNamedContextPropagatorPresent {
+
+        @Autowired
+        private ApplicationContext applicationContext;
+
+        @Test
+        @DisplayName("auto-composed contextPropagator is a Composite that includes the custom propagator in the chain")
+        void customPropagatorJoinsChain() {
+            ContextPropagator propagator = applicationContext.getBean("contextPropagator", ContextPropagator.class);
+            assertThat(propagator).isInstanceOf(CompositeContextPropagator.class);
+
+            CustomNamedPropagatorConfig.MarkerPropagator marker =
+                    applicationContext.getBean(CustomNamedPropagatorConfig.MarkerPropagator.class);
+            marker.wrapped.set(false);
+            // Composing the chain must invoke every member propagator's wrap() — proving the custom
+            // bean was gathered into the composite alongside the always-on MdcContextPropagator.
+            propagator.wrap(() -> { });
+            assertThat(marker.wrapped.get()).isTrue();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomNamedPropagatorConfig {
+
+        static class MarkerPropagator implements ContextPropagator {
+            final AtomicBoolean wrapped = new AtomicBoolean(false);
+            @Override public @NonNull Runnable wrap(@NonNull Runnable task) {
+                wrapped.set(true);
+                return task;
+            }
+        }
+
+        @Bean("myCustomPropagator")
+        public ContextPropagator myCustomPropagator() {
+            return new MarkerPropagator();
         }
     }
 

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverMonitoringAutoConfigurationTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/FailoverMonitoringAutoConfigurationTest.java
@@ -30,6 +30,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.Status;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -62,6 +65,22 @@ class FailoverMonitoringAutoConfigurationTest {
      */
     private final ApplicationContextRunner micrometerRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(FailoverMicrometerAutoConfiguration.class))
+            .withBean(FailoverScanner.class, () -> mock(FailoverScanner.class))
+            .withBean(FailoverExpiryExtractor.class, () -> mock(FailoverExpiryExtractor.class));
+
+    /**
+     * Runner that lets Spring Boot's own metrics autoconfigurations create the {@link MeterRegistry}
+     * (instead of hand-registering one as a user bean). This is the only configuration that exercises
+     * the real autoconfiguration ordering: {@link FailoverMicrometerAutoConfiguration} must be ordered
+     * <em>after</em> the Boot metrics autoconfigurations, otherwise its {@code @ConditionalOnBean(MeterRegistry)}
+     * sees no registry and silently backs off.
+     */
+    private final ApplicationContextRunner autoConfiguredRegistryRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    MetricsAutoConfiguration.class,
+                    CompositeMeterRegistryAutoConfiguration.class,
+                    SimpleMetricsExportAutoConfiguration.class,
+                    FailoverMicrometerAutoConfiguration.class))
             .withBean(FailoverScanner.class, () -> mock(FailoverScanner.class))
             .withBean(FailoverExpiryExtractor.class, () -> mock(FailoverExpiryExtractor.class));
 
@@ -142,6 +161,31 @@ class FailoverMonitoringAutoConfigurationTest {
         void failoverMeterBinderNotRegisteredWithoutRegistry() {
             micrometerRunner.run(ctx ->
                 assertThat(ctx.getBeansOfType(FailoverMeterBinder.class)).isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Micrometer — ordering regression: publisher registered when the MeterRegistry is auto-configured by Spring Boot")
+    class WhenMeterRegistryAutoConfigured {
+
+        /**
+         * Regression for the auto-configuration ordering bug: when the {@link MeterRegistry} is
+         * contributed by Spring Boot's own metrics autoconfigurations (the real-world case) rather
+         * than hand-registered as a user bean, {@link FailoverMicrometerAutoConfiguration} must still
+         * see it and register the {@link MicrometerObservablePublisher}. Without the {@code afterName}
+         * ordering on {@link FailoverMicrometerAutoConfiguration}, this autoconfiguration runs before
+         * the registry exists, its {@code @ConditionalOnBean} fails, and the app silently falls back
+         * to {@code MdcLoggerObservablePublisher} only.
+         */
+        @Test
+        @DisplayName("auto-configured MeterRegistry is visible to FailoverMicrometerAutoConfiguration → MicrometerObservablePublisher registered")
+        void publisherRegisteredWhenRegistryAutoConfigured() {
+            autoConfiguredRegistryRunner.run(ctx -> {
+                assertThat(ctx).hasSingleBean(MeterRegistry.class);
+                assertThat(ctx.getBeansOfType(ObservablePublisher.class).values())
+                        .anyMatch(MicrometerObservablePublisher.class::isInstance);
+                assertThat(ctx).hasSingleBean(FailoverMeterBinder.class);
+            });
         }
     }
 

--- a/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/MicrometerTracingAutoConfigurationTest.java
+++ b/failover-spring-boot-autoconfigure/src/test/java/com/societegenerale/failover/configuration/MicrometerTracingAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import io.micrometer.tracing.Tracer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -73,6 +74,31 @@ class MicrometerTracingAutoConfigurationTest {
         void doesNotRegisterMicrometerContextPropagator() {
             contextRunner
                     .run(ctx -> assertThat(ctx).doesNotHaveBean(MicrometerContextPropagator.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("autoconfiguration ordering")
+    class Ordering {
+
+        /**
+         * The {@code Tracer} that {@code @ConditionalOnBean(Tracer.class)} gates on is contributed by
+         * Spring Boot's own tracing autoconfigurations (Brave / OpenTelemetry). This autoconfiguration
+         * must therefore be ordered <em>after</em> them, or the condition is evaluated before the
+         * {@code Tracer} exists and {@link MicrometerContextPropagator} silently never registers.
+         * A behavioural test would require Brave/OTel test dependencies (only the micrometer-tracing
+         * API is on the test classpath), so this guards the ordering declaration directly to prevent
+         * accidental removal. See finding A6 in the audit report.
+         */
+        @Test
+        @DisplayName("declared after the Spring Boot Brave/OpenTelemetry tracing autoconfigurations")
+        void orderedAfterBootTracingAutoConfigurations() {
+            AutoConfiguration annotation =
+                    MicrometerTracingAutoConfiguration.class.getAnnotation(AutoConfiguration.class);
+            assertThat(annotation).isNotNull();
+            assertThat(annotation.afterName()).contains(
+                    "org.springframework.boot.micrometer.tracing.brave.autoconfigure.BraveAutoConfiguration",
+                    "org.springframework.boot.micrometer.tracing.otel.autoconfigure.OpenTelemetryTracingAutoConfiguration");
         }
     }
 }

--- a/final-audit-report.md
+++ b/final-audit-report.md
@@ -1,0 +1,254 @@
+# Failover — Code Audit & Review Report
+
+**Project:** `failover` — Spring Boot library for transparent referential failover (store-and-replay)
+**Audit date:** 2026-06-15
+**Branch reviewed:** `phase-4-improvrments`
+**Reviewer:** Automated code audit (Claude)
+**Scope:** Design / architecture · code quality · documentation · testability
+
+> Method note: this audit reads the live source tree. The repository's knowledge graph
+> (`graphify-out/`) was generated on 2026-06-08 and predates recent commits (e.g.
+> `audit-driven hardening`, the per-backend package split). Where the graph lists historical
+> review findings (`FINDING-03…13`), those were **verified against current code** and found
+> already remediated. Conclusions below reflect the code as it stands today, not the graph.
+
+---
+
+## 1. Executive Summary
+
+`failover` is a **mature, well-architected, production-grade** Spring Boot library. It exhibits
+the discipline of a published OSS component: Apache-2.0 headers on every file, exhaustive Javadoc,
+null-safety annotations, a 16-module reactor with clean layering, and an unusually strong test
+and quality-gate posture (88 unit + 9 integration tests, 95% mutation threshold, ArchUnit rules,
+concurrency tests against real H2).
+
+The codebase is in a **release-ready** state. The improvement areas identified are refinements and
+hardening of already-good practices — not defects blocking use. There is **one documentation bug**
+worth fixing promptly (a broken entry-point pointer in `CLAUDE.md`).
+
+### Scorecard
+
+| Dimension | Grade | Summary |
+|---|:---:|---|
+| Design / Architecture | **A** | Clean decorator chain, SPI everywhere, zero import cycles, strong module boundaries |
+| Code Quality | **A−** | Modern Java 21, documented edge cases, 0 TODO/`System.out`; a few large classes & micro-perf spots |
+| Documentation | **A−** | ADRs, MkDocs site, per-package `package-info`; one broken pointer + a generated-metadata gap |
+| Testability | **A** | High test:code ratio, mutation + arch + concurrency testing; ITs concentrated in one module by design |
+
+**Overall: A− (excellent).**
+
+---
+
+## 2. Project at a Glance
+
+| Metric | Value |
+|---|---|
+| Reactor modules | 16 + aggregate `report` |
+| Main source | ~9,500 LOC Java |
+| Test source | ~18,300 LOC Java (**~1.9 : 1** test-to-main) |
+| Unit tests (`*Test.java`) | 88 |
+| Integration tests (`*IT.java`) | 9 (real H2) |
+| Auto-configuration classes | 22 |
+| Java / Spring Boot | **21 / 4.0.6** |
+| Null-safety | JSpecify 1.0.0 |
+| Mutation testing | PIT, **threshold 95%** |
+| Architecture tests | ArchUnit 1.3.0 |
+| `TODO`/`FIXME` in main | **0** |
+| `System.out` / `printStackTrace` in main | **0** |
+| Import cycles | **0** (per graph analysis) |
+
+---
+
+## 3. Design & Architecture
+
+### 3.1 What is good
+
+- **Decorator handler chain is textbook.** Responsibilities are cleanly separated and each layer
+  is independently testable:
+  ```
+  AdvancedFailoverHandler        ← metrics, RecoveredPayloadHandler, exception policy
+    └── ScatterGatherFailoverHandler   ← split composite result into per-entity slices
+          └── DefaultFailoverHandler     ← core store/recover, expiry check
+  ```
+- **Store assembly is composable** via decorators: `AsyncFailoverStore → MultiTenantFailoverStore → {InMemory | Caffeine | JDBC | custom}`.
+- **SPI-first extensibility.** Every core bean is `@ConditionalOnMissingBean`; consumers swap
+  `KeyGenerator`, `ExpiryPolicy`, `PayloadSplitter`, `RecoveredPayloadHandler`, `ContextPropagator`,
+  `DatabaseResolver`, `TenantResolver`, etc. by declaring a bean. This is the strongest design trait.
+- **Decisions are recorded.** 27+ ADRs document non-obvious choices (Instant-over-LocalDateTime for
+  timezone-aware expiry, defensive-copy contract, native merge/upsert dialect detection, outermost
+  multi-tenant routing, parallel scatter executor injection).
+- **Clean module boundaries.** Per-backend stores are isolated modules; `failover-domain` holds only
+  the annotation contract; resilience and observability are opt-in modules. No cyclic dependencies.
+- **Modern concurrency.** Virtual-thread executor for async writes and parallel scatter; per-slice
+  timeout handling that degrades a timed-out recover slice to "not recovered" rather than hanging the
+  business thread (`ScatterGatherFailoverHandler#zip`).
+
+### 3.2 What to improve
+
+| # | Area | Observation | Severity |
+|---|---|---|:---:|
+| A1 | **Stale auto-config registration** ✅ **RESOLVED (2026-06-15)** | `META-INF/spring.factories` carried an `EnableAutoConfiguration=` block that (a) Spring Boot 4 **ignored** in favour of `AutoConfiguration.imports`, and (b) referenced **two classes that no longer exist** — `FailoverCaffeineStoreAutoConfiguration` and `FailoverJdbcStoreAutoConfiguration` (removed in the per-backend package split). **Fix:** dead block deleted; valid `FailureAnalyzer=` registration retained. Stale Javadoc in `FailoverAutoConfiguration` naming the same deleted classes also corrected. Live registration via `AutoConfiguration.imports` unaffected. | ~~Medium~~ |
+| A5 | **Micrometer (metrics) autoconfig ordering** ✅ **RESOLVED (2026-06-15)** | `FailoverMicrometerAutoConfiguration` was ordered only `@AutoConfiguration(after = FailoverAutoConfiguration.class)`. The `MeterRegistry` it gates on (`@ConditionalOnBean(MeterRegistry.class)`) is contributed by Spring Boot's **own** metrics autoconfigurations; with no ordering relative to them, the condition was evaluated **before** the registry existed, so the bean silently backed off and the app fell back to `MdcLoggerObservablePublisher` only — **no Micrometer metrics in production**. The unit tests masked it by injecting `MeterRegistry` as a *user bean* (always visible before conditions). **Fix:** added `afterName` ordering against the Boot metrics autoconfigurations (`MetricsAutoConfiguration`, `CompositeMeterRegistryAutoConfiguration`, `SimpleMetricsExportAutoConfiguration`) — by name, so no compile-time dependency is introduced. Added a regression test (`WhenMeterRegistryAutoConfigured`) that lets Boot **auto-configure** the registry; verified it **fails** without the fix and **passes** with it. | ~~High~~ |
+| A6 | **Micrometer tracing autoconfig ordering** ✅ **RESOLVED (2026-06-15)** | Same class of bug found by auditing all `@ConditionalOnBean` sites: `MicrometerTracingAutoConfiguration` gates `MicrometerContextPropagator` on `@ConditionalOnBean(Tracer.class)` but was ordered only after `FailoverAutoConfiguration`. The `Tracer` is contributed by Spring Boot's Brave/OpenTelemetry tracing autoconfigurations — so on the same ordering race, scatter/gather slices silently **lose span propagation**. **Fix:** added `afterName` ordering against the Boot tracing autoconfigurations (`MicrometerTracingAutoConfiguration`, `brave…BraveAutoConfiguration`, `otel…OpenTelemetryTracingAutoConfiguration`). Added an ordering-guard test (only the micrometer-tracing API is on the test classpath, so a behavioural test would need Brave/OTel deps). *(Note: `FailoverStoreAutoConfiguration`'s `@ConditionalOnBean(TenantStoreFactory)` was checked and is **correctly** ordered after its contributor — no fix needed.)* | ~~High~~ |
+| A2 | `ScatterGatherFailoverHandler` size | ~405 lines, three constructors, scatter + gather + timeout + zip in one class. Cohesive but dense; a future split (scatter vs. gather collaborators) would ease maintenance. | Low |
+| A3 | Metrics construction on hot path | `AdvancedFailoverHandler` builds a `Metrics` map with many string concatenations/boxing on **every** store/recover. Fine today (failover path only), but worth a micro-benchmark if recover rates climb. | Info |
+| A4 | JDBC insert→update race | `FailoverStoreJdbc#insertOrUpdate` has a documented race window (concurrent expiry delete drops a write). Acceptable for a regenerable cache and avoided by the native-merge path, but remains an unhandled edge for non-merge dialects. | Info |
+
+---
+
+## 4. Code Quality
+
+### 4.1 What is good
+
+- **Uniform hygiene.** Apache-2.0 header on every file; consistent Lombok usage
+  (`@AllArgsConstructor`, `@Slf4j`); zero `TODO`/`FIXME`, zero `System.out`/`printStackTrace` in main.
+- **Null-safety is real, not decorative.** JSpecify `@Nullable`/`@NonNull` on the handler and
+  splitter APIs, and the nullness contract is honoured in the logic.
+- **Edge cases are reasoned about in-code.** Standout examples:
+  - `FailoverAspect#returnResult` deliberately **re-throws `Error`** (OOM/StackOverflow) so recovery
+    never runs on a failing JVM — only `Throwable` is wrapped.
+  - `DefaultKeyGenerator` detects types that override `toString()` and **warns** when an identity
+    hash would be used (unstable across JVM restarts with a persistent store) — a genuine correctness
+    trap, surfaced rather than hidden (prior `FINDING-07` fully remediated).
+  - `AdvancedFailoverHandler#recover` swallows recovery-path exceptions **intentionally and loudly**
+    (logged), delegating the null to `RecoveredPayloadHandler` (prior `FINDING-04` remediated).
+  - `FailoverStoreJdbc` degrades from native merge to INSERT/UPDATE on `BadSqlGrammarException`,
+    flips an `AtomicBoolean` once, and documents the race window.
+- **Defensive-copy contract** on `FailoverStore.find` is documented and respected — callers mutate
+  `upToDate`/`asOf` without corrupting stored data.
+
+### 4.2 What to improve
+
+| # | Area | Observation | Severity |
+|---|---|---|:---:|
+| Q1 | Naming | `DefaultKeyGenerator.NUMBER_TYPES` holds `Number`, `String`, `Boolean` — the name under-describes its contents (rename to e.g. `SCALAR_TYPES`). | Trivial |
+| Q2 | Metric string-building | Repeated `Long.toString(...)`/ternary-to-`""` patterns in `AdvancedFailoverHandler` are verbose and allocation-heavy; a small helper would cut duplication. | Low |
+| Q3 | `@SuppressWarnings` | 2 occurrences in main, both `"unchecked"` on generic casts (`CastingUtils`, `RethrowIfNoRecoveryMethodExceptionPolicy`) — **legitimate**; optional clarifying comment only. | Trivial |
+| Q4 | Logging volume | `INFO`-level logs on every store/recover (with full payload `toString`) may be chatty in high-throughput services; consider `DEBUG` for payload bodies. | Low |
+
+---
+
+## 5. Documentation
+
+### 5.1 What is good
+
+- **Layered, navigable docs**: MkDocs Material site with getting-started, concepts, how-to guides
+  (custom key generator, expiry, payload enricher, splitter, exception policy, multi-tenant,
+  observability), configuration reference, modules, ADRs, and a changelog.
+- **`package-info.java` in every package** — rare and valuable; it makes the Javadoc tree coherent.
+- **Method- and class-level Javadoc is thorough**, including parameter semantics, null behaviour, and
+  cross-references (`{@link …}`).
+- Top-level docs (`README`, `CONTRIBUTING`, `SECURITY`, `LICENSE`) and a quality section documenting
+  mutation, architecture, integration, and concurrency testing.
+
+### 5.2 What to improve
+
+| # | Area | Observation | Severity |
+|---|---|---|:---:|
+| **D1** | **Broken entry pointer** ✅ **RESOLVED (2026-06-15)** | `CLAUDE.md` instructed: *"Use `graphify-out/wiki/index.md` as your entry point"* — that directory never existed. **Fix:** repointed to `graphify-out/GRAPH_REPORT.md`, the real graph artifact present in the tree. | ~~Medium~~ |
+| D2 | Config metadata | No `additional-spring-configuration-metadata.json`; only the generated `spring-configuration-metadata.json` exists. Hand-authored metadata would give IDE autocomplete + descriptions for custom properties. | Low |
+| D3 | Stale knowledge graph | `graphify-out/` is dated 2026-06-08 and predates recent commits; its `FINDING-*` nodes describe already-fixed issues. Regenerate to avoid future readers acting on stale findings. | Low |
+
+---
+
+## 6. Testability
+
+### 6.1 What is good
+
+- **High coverage breadth and depth**: ~1.9:1 test-to-main LOC, 88 unit tests, 9 real-H2 integration
+  tests, **PIT mutation testing at a 95% threshold** (very demanding), and **ArchUnit** rules guarding
+  layering.
+- **Determinism by design**: integration tests run with `failover.store.async=false` so writes are
+  synchronous and assertions are stable.
+- **Concurrency is tested**, not assumed (dedicated concurrency scenarios for the JDBC/multi-tenant
+  stores).
+- **Clear conventions** (`*Test.java` = Surefire/Mockito, `*IT.java` = Failsafe/Spring) and AssertJ
+  throughout, matching the project's stated standards.
+
+### 6.2 What to improve
+
+| # | Area | Observation | Severity |
+|---|---|---|:---:|
+| T1 | No coverage gate | PIT enforces a mutation threshold, but **JaCoCo has no `check`/`<minimum>` rule** — line/branch coverage is reported (for Sonar) but not gated in the build. Add a JaCoCo `check` execution to prevent regressions. | Low |
+| T2 | IT concentration | All integration tests live in `failover-spring-boot-autoconfigure` by design. It centralises wiring tests but makes that module heavy and couples backend IT failures to one place. | Info |
+| T3 | Cross-DB coverage | ITs run against H2; PostgreSQL/MySQL/MariaDB/Oracle dialects are exercised via resolver unit tests but not a live container. Testcontainers ITs would harden dialect detection. | Low |
+| T4 | `@ConditionalOnBean` tests masked a real bug (see **A5**) | Autoconfig tests that supply the gated bean as a **user bean** (`.withBean(MeterRegistry…)`) always satisfy `@ConditionalOnBean` regardless of ordering, so they hid the production ordering failure. **Lesson applied:** for any `@ConditionalOnBean` on a bean contributed by *another* autoconfiguration, add a test that registers the **real** contributing autoconfigurations via `AutoConfigurations.of(...)` (no hand-injected bean). A `grep` for other `@ConditionalOnBean` usages on framework-contributed types is worthwhile. | Low |
+
+---
+
+## 7. Improvement Plan (Phased)
+
+Phased so each phase is independently shippable and ordered by value-to-effort.
+
+### Phase 1 — Documentation & build hygiene (low risk, fast)
+**Goal:** remove the one real doc bug and close cheap gaps.
+1. ✅ **D1 DONE** — `CLAUDE.md` entry-point pointer repointed to `graphify-out/GRAPH_REPORT.md`.
+2. **D3** Regenerate the knowledge graph (`/graphify`) so `FINDING-*` nodes reflect current code.
+3. ✅ **A1 DONE** — dead `EnableAutoConfiguration=` block deleted from `META-INF/spring.factories`
+   (`FailureAnalyzer=` retained); stale Javadoc in `FailoverAutoConfiguration` corrected.
+4. **Q1/Q3** Rename `NUMBER_TYPES → SCALAR_TYPES`. (`@SuppressWarnings` audited: 2 in main, both
+   `"unchecked"` on generic casts in `CastingUtils` and `RethrowIfNoRecoveryMethodExceptionPolicy` —
+   legitimate; no action beyond an optional clarifying comment.)
+
+*Exit:* docs accurate, no dead config, naming clarified. No behavioural change.
+
+### Phase 2 — Test gates (low risk, prevents regression)
+**Goal:** lock in the already-high quality.
+1. **T1** Add a JaCoCo `check` execution with line/branch minimums (start at current measured levels,
+   e.g. 90%/80%, fail the build below).
+2. **D2** Author `additional-spring-configuration-metadata.json` for custom `failover.*` properties
+   (descriptions, defaults, enum hints) to enrich IDE support.
+
+*Exit:* coverage regressions fail CI; consumers get autocomplete for all properties.
+
+### Phase 3 — Robustness hardening (medium effort, additive)
+**Goal:** strengthen the data-layer and observability edges.
+1. **T3** Add Testcontainers ITs for PostgreSQL (and optionally MySQL) to exercise native merge SQL
+   and dialect detection on real engines.
+2. **A4** Decide the policy for the JDBC insert→update race on non-merge dialects: document as
+   accepted, or add a single bounded retry. (Native-merge dialects already avoid it.)
+3. **Q4** Move payload-body logging from `INFO` to `DEBUG`; keep lifecycle events at `INFO`.
+
+*Exit:* dialect paths verified on real DBs; logging production-friendly; race policy explicit.
+
+### Phase 4 — Refactor & performance polish (optional, lowest priority)
+**Goal:** maintainability and micro-perf, only if churn justifies it.
+1. **A2** Extract scatter and gather collaborators from `ScatterGatherFailoverHandler` to reduce class size.
+2. **A3/Q2** Introduce a small `Metrics` builder helper to remove repeated `toString`/ternary noise
+   and reduce per-call allocation on the recover path; back with a micro-benchmark.
+
+*Exit:* smaller, cheaper hot path; no functional change.
+
+---
+
+## 8. Risk Register
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|---|---|:---:|:---:|---|
+| D1 | ✅ **Resolved** — pointer repointed to `graphify-out/GRAPH_REPORT.md` | — | — | Done 2026-06-15 |
+| A1 | ✅ **Resolved** — dead `spring.factories` block deleted, Javadoc corrected | — | — | Done 2026-06-15 |
+| A5 | ✅ **Resolved** — Micrometer metrics autoconfig now ordered after Boot metrics autoconfigs; regression test added | — | — | Done 2026-06-15 |
+| A6 | ✅ **Resolved** — Micrometer tracing autoconfig now ordered after Boot tracing autoconfigs; ordering-guard test added | — | — | Done 2026-06-15 |
+| T1 | Silent coverage regression over time | Med | Med | Phase 2 JaCoCo gate |
+| A4 | JDBC write dropped under concurrent expiry (non-merge dialect) | Low | Low | Documented; Phase 3 policy |
+| T3 | Dialect bug surfaces only in production DB | Low | Med | Phase 3 Testcontainers |
+
+---
+
+## 9. Conclusion
+
+`failover` is a **high-quality, well-documented, thoroughly tested** library that reflects deliberate
+architectural decisions and sustained engineering discipline. Historical review findings have been
+addressed, the design is genuinely extensible, and the test posture (mutation + architecture +
+concurrency) exceeds typical industry practice.
+
+The recommended work is **incremental hardening**, not repair. The single highest-priority item is the
+trivial **Phase 1 / D1** documentation-pointer fix; everything else is optional polish that further
+raises an already-strong bar.
+
+**Final grade: A− (excellent, release-ready).**
+
+---
+
+*Generated from a live source-tree audit. Knowledge-graph artifacts were treated as background and
+re-verified against current code, per the note in §1.*


### PR DESCRIPTION
… stale registration

Two @ConditionalOnBean autoconfigurations gated on framework-contributed beans were not ordered after the Spring Boot autoconfigurations that create those beans. Because @ConditionalOnBean only sees beans registered by autoconfigurations evaluated earlier, the conditions were evaluated before the bean existed and the failover beans silently backed off:

- FailoverMicrometerAutoConfiguration gates on MeterRegistry. With no ordering relative to Boot's metrics autoconfigurations, MicrometerObservable- Publisher was never registered and the app fell back to MdcLoggerObservable- Publisher only — no Micrometer metrics in production.
- MicrometerTracingAutoConfiguration gates on Tracer (Brave/OpenTelemetry). On the same race, scatter/gather slices silently lost span propagation.

The existing tests masked both by supplying the gated bean as a user bean, which is always visible before autoconfiguration conditions are evaluated.

Fixes:
- Add @AutoConfiguration afterName ordering against the Boot metrics autoconfigurations (MetricsAutoConfiguration, CompositeMeterRegistry- AutoConfiguration, SimpleMetricsExportAutoConfiguration) and the Boot tracing autoconfigurations (MicrometerTracing / Brave / OpenTelemetry). Referenced by name so no compile-time dependency is introduced.
- Add a regression test that lets Spring Boot auto-configure the MeterRegistry (no hand-injected bean); verified to fail without the fix and pass with it.
- Add an ordering-guard test for the tracing autoconfiguration (only the micrometer-tracing API is on the test classpath).

Also remove the dead EnableAutoConfiguration block from spring.factories (ignored by Spring Boot 4 and referencing two classes deleted in the per-backend package split); the FailureAnalyzer registration is retained. Correct the matching stale Javadoc in FailoverAutoConfiguration, and repoint the CLAUDE.md graph entry pointer to the existing GRAPH_REPORT.md.

Adds final-audit-report.md documenting the full design/quality/docs/test audit and these findings (A1, A5, A6, D1).

FailoverStoreAutoConfiguration's @ConditionalOnBean(TenantStoreFactory) was checked and is already correctly ordered after its contributor.

## Summary
<!-- Provide a general summary description of your changes -->

## Details
<!-- Describe your changes in detail and the context -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I've added tests for my code.
- [ ] Documentation has been updated accordingly to this PR
- [ ] I have verified all the modules and confirmed no impacts

## Related issue :
<!-- If it fixes an open issue, please link to the issue here. -->